### PR TITLE
Button timeout issue fix

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -278,6 +278,8 @@ async def on_message(message):
 
 class Chat(discord.ui.View):
     @discord.ui.button(label="Chat now!", style=discord.ButtonStyle.primary)
+     def __init__(self):
+        super().__init__(timeout=None)
     async def button_callback(self, button, interaction):
         user = interaction.user
         chat_id = str(uuid.uuid4())[:8]


### PR DESCRIPTION
Discord.py's "discord.ui.View" have a default timeout of 180 seconds which made the button not work (with the error "interaction failed") after a certain time. This fix makes the button not time out. 

Reference: https://discordpy.readthedocs.io/en/latest/interactions/api.html?highlight=view#discord.ui.View.timeout